### PR TITLE
Add unit tests for MapedSqlTokenParser and StringTokenParser

### DIFF
--- a/src/test/java/org/yx/db/sql/token/MapedSqlTokenParserTest.java
+++ b/src/test/java/org/yx/db/sql/token/MapedSqlTokenParserTest.java
@@ -1,0 +1,32 @@
+package org.yx.db.sql.token;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.yx.db.sql.MapedSql;
+
+import java.util.ArrayList;
+
+public class MapedSqlTokenParserTest {
+
+  @Test
+  public void testParse() {
+    final MapedSql parsed = new MapedSqlTokenParser("<", ">", null).parse("");
+    Assert.assertNotNull(parsed);
+    Assert.assertEquals("", parsed.getSql());
+    Assert.assertNull(parsed.getEvent());
+    Assert.assertEquals(new ArrayList<>(), parsed.getParamters());
+
+    final MapedSql parsed2 = new MapedSqlTokenParser("<", ">", null).parse(null);
+    Assert.assertNotNull(parsed2);
+    Assert.assertEquals("", parsed2.getSql());
+    Assert.assertNull(parsed2.getEvent());
+    Assert.assertEquals(new ArrayList<>(), parsed2.getParamters());
+
+    final MapedSql parsed3 = new MapedSqlTokenParser("<", ">", null).parse("text");
+    Assert.assertNotNull(parsed3);
+    Assert.assertEquals("text", parsed3.getSql());
+    Assert.assertNull(parsed3.getEvent());
+    Assert.assertEquals(new ArrayList<>(), parsed3.getParamters());
+  }
+
+}

--- a/src/test/java/org/yx/db/sql/token/StringTokenParserTest.java
+++ b/src/test/java/org/yx/db/sql/token/StringTokenParserTest.java
@@ -1,0 +1,16 @@
+package org.yx.db.sql.token;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class StringTokenParserTest {
+
+  @Test
+  public void testParse() {
+    final StringTokenParser objectUnderTest = new StringTokenParser("<", ">", null);
+    Assert.assertEquals("", objectUnderTest.parse(""));
+    Assert.assertEquals("", objectUnderTest.parse(null));
+    Assert.assertEquals("text", objectUnderTest.parse("text"));
+  }
+
+}


### PR DESCRIPTION
Hi, I've analysed your codebase and seen some gaps in the coverage of:

org.yx.db.sql.token.MapedSqlTokenParser
org.yx.db.sql.token.StringTokenParser

I've written tests with the help of [Diffblue Cover](https://www.diffblue.com/products) and increased line coverage for these classes from 0% to approximately 50% (IntelliJ). Hopefully, they will help you detect regressions caused by future code changes.
I noticed that "skipTests" is set to "true" in pom.xml so this would need to change in order for these tests to run.